### PR TITLE
support tsvector column mapping without "options" parameter

### DIFF
--- a/EventListener/SearchListener.php
+++ b/EventListener/SearchListener.php
@@ -22,12 +22,12 @@ class SearchListener
                     continue;
                 }
 
-                $fieldMapping = $metadata->getFieldMapping($field)['options'];
-                if (!isset($fieldMapping['customSchemaOptions']['searchFields'])) {
+                $fieldMapping = $metadata->getFieldMapping($field);
+                if (!isset($fieldMapping['options']['customSchemaOptions']['searchFields'])) {
                     continue;
                 }
 
-                $searchFields = $fieldMapping['customSchemaOptions']['searchFields'];
+                $searchFields = $fieldMapping['options']['customSchemaOptions']['searchFields'];
                 $searchData = [];
                 foreach ($searchFields as $searchField) {
                     $getter = 'get' . ucfirst($searchField);
@@ -56,13 +56,13 @@ class SearchListener
                     continue;
                 }
 
-                $fieldMapping = $metadata->getFieldMapping($field)['options'];
-                if (!isset($fieldMapping['customSchemaOptions']['searchFields'])) {
+                $fieldMapping = $metadata->getFieldMapping($field);
+                if (!isset($fieldMapping['options']['customSchemaOptions']['searchFields'])) {
                     continue;
                 }
 
                 $updateNeeded = false;
-                $searchFields = $fieldMapping['customSchemaOptions']['searchFields'];
+                $searchFields = $fieldMapping['options']['customSchemaOptions']['searchFields'];
                 foreach ($changeSet as $fieldName => $value) {
                     if (in_array($fieldName, $searchFields)) {
                         $updateNeeded = true;


### PR DESCRIPTION
If you do not specify "options" parameter in column mapping, `SearchListener` raises:
`Notice: Undefined index: options`.
See https://github.com/1on/postgres-search-bundle/blob/8e0a695debc0a3b9b12652c571ba131554ce4473/EventListener/SearchListener.php#L25 .
